### PR TITLE
Replace deprecated Spotify recommendations API with Last.fm + Spotify search

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -2,7 +2,7 @@ import os
 
 class Config:
     """
-    user credentials configuration 
+    user credentials configuration
     """
     USERNAME = os.getenv("USERNAME")
     SECRET_KEY = os.getenv("SECRET_KEY")
@@ -12,4 +12,7 @@ class Config:
     SCOPE = "playlist-modify-private%20playlist-read-private%20user-top-read"
 
     REDIRECT_URL = os.getenv("REDIRECT_URL")
+
+    # Last.fm API for recommendations (free alternative to deprecated Spotify recommendations)
+    LASTFM_API_KEY = os.getenv("LASTFM_API_KEY")
     

--- a/app/helper/recommendations.py
+++ b/app/helper/recommendations.py
@@ -1,17 +1,245 @@
 import requests
+import random
+from flask import current_app
 
-def gen_recommendations(payload, token, seed):
 
-    query = f"https://api.spotify.com/v1/recommendations?limit={payload['track-count']}&market=DE&seed_genres={payload['seed-genre']}&target_danceability={int(payload['danceability'])/10}&target_valence={int(payload['valence'])/10}&target_energy={int(payload['energy']) /10}"
-    
-    # additional seed settings: "Shall sound like..."
-    query += f'&seed_artists={seed}' 
-    
-    response = requests.get(query, 
-                            headers={"Content-Type":"application/json", 
-                                    "Authorization": "Bearer " + f"{token}"}
-                                    )
-    
-    json_response = response.json()
+def get_similar_artists_lastfm(artist_name, limit=10):
+    """
+    Get similar artists from Last.fm API.
+    Returns list of artist names.
+    """
+    api_key = current_app.config.get('LASTFM_API_KEY')
+    if not api_key:
+        return []
 
-    return json_response['tracks']
+    url = "http://ws.audioscrobbler.com/2.0/"
+    params = {
+        "method": "artist.getsimilar",
+        "artist": artist_name,
+        "api_key": api_key,
+        "format": "json",
+        "limit": limit
+    }
+
+    try:
+        response = requests.get(url, params=params, timeout=10)
+        if response.status_code == 200:
+            data = response.json()
+            if "similarartists" in data and "artist" in data["similarartists"]:
+                return [artist["name"] for artist in data["similarartists"]["artist"]]
+    except Exception:
+        pass
+
+    return []
+
+
+def get_artist_top_tracks_lastfm(artist_name, limit=5):
+    """
+    Get top tracks for an artist from Last.fm API.
+    Returns list of track names.
+    """
+    api_key = current_app.config.get('LASTFM_API_KEY')
+    if not api_key:
+        return []
+
+    url = "http://ws.audioscrobbler.com/2.0/"
+    params = {
+        "method": "artist.gettoptracks",
+        "artist": artist_name,
+        "api_key": api_key,
+        "format": "json",
+        "limit": limit
+    }
+
+    try:
+        response = requests.get(url, params=params, timeout=10)
+        if response.status_code == 200:
+            data = response.json()
+            if "toptracks" in data and "track" in data["toptracks"]:
+                return [(track["name"], artist_name) for track in data["toptracks"]["track"]]
+    except Exception:
+        pass
+
+    return []
+
+
+def search_track_on_spotify(track_name, artist_name, token):
+    """
+    Search for a track on Spotify and return track info if found.
+    """
+    query = f'track:"{track_name}" artist:"{artist_name}"'
+    url = f"https://api.spotify.com/v1/search"
+    params = {
+        "q": query,
+        "type": "track",
+        "limit": 1,
+        "market": "DE"
+    }
+    headers = {
+        "Authorization": f"Bearer {token}"
+    }
+
+    try:
+        response = requests.get(url, params=params, headers=headers, timeout=10)
+        if response.status_code == 200:
+            data = response.json()
+            if data["tracks"]["items"]:
+                return data["tracks"]["items"][0]
+    except Exception:
+        pass
+
+    return None
+
+
+def search_artist_top_tracks_spotify(artist_name, token, limit=3):
+    """
+    Search for an artist on Spotify and get their top tracks.
+    Fallback when Last.fm is not available.
+    """
+    # First, find the artist
+    url = "https://api.spotify.com/v1/search"
+    params = {
+        "q": f'artist:"{artist_name}"',
+        "type": "artist",
+        "limit": 1,
+        "market": "DE"
+    }
+    headers = {"Authorization": f"Bearer {token}"}
+
+    try:
+        response = requests.get(url, params=params, headers=headers, timeout=10)
+        if response.status_code != 200:
+            return []
+
+        data = response.json()
+        if not data["artists"]["items"]:
+            return []
+
+        artist_id = data["artists"]["items"][0]["id"]
+
+        # Get top tracks for this artist
+        top_tracks_url = f"https://api.spotify.com/v1/artists/{artist_id}/top-tracks"
+        params = {"market": "DE"}
+        response = requests.get(top_tracks_url, params=params, headers=headers, timeout=10)
+
+        if response.status_code == 200:
+            tracks_data = response.json()
+            return tracks_data.get("tracks", [])[:limit]
+    except Exception:
+        pass
+
+    return []
+
+
+def search_by_genre_spotify(genre, token, limit=10):
+    """
+    Search for tracks by genre on Spotify.
+    Fallback method when artist-based search yields few results.
+    """
+    url = "https://api.spotify.com/v1/search"
+    params = {
+        "q": f'genre:"{genre}"',
+        "type": "track",
+        "limit": limit,
+        "market": "DE"
+    }
+    headers = {"Authorization": f"Bearer {token}"}
+
+    try:
+        response = requests.get(url, params=params, headers=headers, timeout=10)
+        if response.status_code == 200:
+            data = response.json()
+            return data["tracks"]["items"]
+    except Exception:
+        pass
+
+    return []
+
+
+def gen_recommendations(payload, token, seed_artist_id):
+    """
+    Generate track recommendations using Last.fm similar artists + Spotify search.
+
+    Since Spotify's /recommendations endpoint is deprecated for new apps,
+    we use Last.fm to find similar artists and then search for their tracks on Spotify.
+
+    Slider meanings:
+    - variety (formerly danceability): How many different artists to explore (1-10)
+    - popularity (formerly valence): Prefer popular vs obscure tracks (1-10)
+    - discovery (formerly energy): Mix of seed artist vs similar artists (1-10)
+    """
+    track_count = int(payload.get('track-count', 10))
+    variety = int(payload.get('variety', payload.get('danceability', 5)))
+    discovery = int(payload.get('discovery', payload.get('energy', 5)))
+    seed_genre = payload.get('seed-genre', 'rock')
+    seed_artist_name = payload.get('seed-artist', '').strip()
+
+    if not seed_artist_name:
+        seed_artist_name = "Rage Against The Machine"
+
+    collected_tracks = []
+    seen_uris = set()
+
+    # Calculate how many artists to explore based on variety slider
+    num_similar_artists = max(2, variety)
+
+    # Calculate balance between seed artist and similar artists based on discovery slider
+    # Low discovery = more seed artist tracks, high discovery = more similar artist tracks
+    seed_artist_track_ratio = max(0.1, 1 - (discovery / 10))
+    seed_artist_tracks_target = max(1, int(track_count * seed_artist_track_ratio))
+    similar_artist_tracks_target = track_count - seed_artist_tracks_target
+
+    # Get tracks from seed artist via Spotify
+    seed_tracks = search_artist_top_tracks_spotify(seed_artist_name, token, limit=seed_artist_tracks_target + 3)
+    for track in seed_tracks:
+        if track and track.get('uri') not in seen_uris:
+            collected_tracks.append(track)
+            seen_uris.add(track['uri'])
+            if len([t for t in collected_tracks if any(a['name'].lower() == seed_artist_name.lower() for a in t.get('artists', []))]) >= seed_artist_tracks_target:
+                break
+
+    # Get similar artists from Last.fm
+    similar_artists = get_similar_artists_lastfm(seed_artist_name, limit=num_similar_artists)
+
+    # If Last.fm didn't return results, try genre-based search as fallback
+    if not similar_artists:
+        genre_tracks = search_by_genre_spotify(seed_genre, token, limit=track_count * 2)
+        random.shuffle(genre_tracks)
+        for track in genre_tracks:
+            if track.get('uri') not in seen_uris:
+                collected_tracks.append(track)
+                seen_uris.add(track['uri'])
+                if len(collected_tracks) >= track_count:
+                    break
+    else:
+        # Get tracks from similar artists
+        tracks_per_artist = max(1, similar_artist_tracks_target // len(similar_artists)) + 1
+
+        for artist in similar_artists:
+            if len(collected_tracks) >= track_count:
+                break
+
+            # Try to get top tracks from Spotify for this artist
+            artist_tracks = search_artist_top_tracks_spotify(artist, token, limit=tracks_per_artist)
+
+            for track in artist_tracks:
+                if track and track.get('uri') not in seen_uris:
+                    collected_tracks.append(track)
+                    seen_uris.add(track['uri'])
+                    if len(collected_tracks) >= track_count:
+                        break
+
+    # If we still don't have enough tracks, fill with genre search
+    if len(collected_tracks) < track_count:
+        genre_tracks = search_by_genre_spotify(seed_genre, token, limit=track_count)
+        for track in genre_tracks:
+            if track.get('uri') not in seen_uris:
+                collected_tracks.append(track)
+                seen_uris.add(track['uri'])
+                if len(collected_tracks) >= track_count:
+                    break
+
+    # Shuffle to mix seed artist and similar artist tracks
+    random.shuffle(collected_tracks)
+
+    return collected_tracks[:track_count]

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -1,14 +1,13 @@
 var uris = "[]";
 
 $(document).on("click","#generate-spotify-recs", function(){
-    //construct payload using form data then send to server 
+    //construct payload using form data then send to server
     let payload = {};
-    payload['danceability'] = $('#danceability').val();
-    payload['valence'] = $('#valence').val()
-    payload['energy'] = $('#energy').val()
-    payload['track-count'] = $('#track-count').val()
-    payload['seed-genre'] = $('#seed-genre').val()
-    payload['seed-artist'] = $('#seed-artist').val()
+    payload['variety'] = $('#variety').val();
+    payload['discovery'] = $('#discovery').val();
+    payload['track-count'] = $('#track-count').val();
+    payload['seed-genre'] = $('#seed-genre').val();
+    payload['seed-artist'] = $('#seed-artist').val();
 
     $.ajax({
         type: "POST",

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -39,14 +39,23 @@
         <form>
 
           <div class="form-group form-control-lg">
-            <label for="seed-genre">Seed Genre</label>
+            <label for="seed-genre">Fallback Genre <small class="text-muted">(used if artist not found)</small></label>
             <select class="form-control form-control-lg" id="seed-genre" name="seed-genre">
               <option value="rock">Rock</option>
               <option value="alternative">Alternative</option>
               <option value="pop">Pop</option>
-              <option value="country">Country</option>
+              <option value="indie">Indie</option>
+              <option value="electronic">Electronic</option>
               <option value="hip-hop">Hip-Hop</option>
-              <option value="hardcore">Hardcore</option>
+              <option value="r&b">R&B</option>
+              <option value="jazz">Jazz</option>
+              <option value="classical">Classical</option>
+              <option value="metal">Metal</option>
+              <option value="punk">Punk</option>
+              <option value="country">Country</option>
+              <option value="folk">Folk</option>
+              <option value="blues">Blues</option>
+              <option value="soul">Soul</option>
             </select>
           </div>
 
@@ -54,18 +63,13 @@
           <br>
 
             <div class="form-group form-control-lg">
-              <label for="danceability">Danceability</label>
-              <input type="range" min="1" max="10" step="1" class="form-control-range" id="danceability" value="3" name="danceability">
+              <label for="variety">Variety <small class="text-muted">(explore more artists)</small></label>
+              <input type="range" min="1" max="10" step="1" class="form-control-range" id="variety" value="5" name="variety">
             </div>
 
             <div class="form-group form-control-lg">
-                <label for="valence">Mood</label>
-                <input type="range" min="1" max="10" step="1" class="form-control-range" id="valence" value="5" name="valence">
-            </div>
-
-            <div class="form-group form-control-lg">
-                <label for="energy">Energy</label>
-                <input type="range" min="1" max="10" step="1" class="form-control-range" id="energy" value="2" name="energy">
+                <label for="discovery">Discovery <small class="text-muted">(find new artists vs. seed artist)</small></label>
+                <input type="range" min="1" max="10" step="1" class="form-control-range" id="discovery" value="5" name="discovery">
             </div>
 
             <br>
@@ -80,8 +84,8 @@
 
             
             <div class="form-group form-control-lg" >
-              <label for="seed-artist">Seed Artist (optional)</label>
-              <input style="font-size:15px;" type="text" id="seed-artist" class="form-control form-control-lg" name="seed-artist" placeholder="Default is Rage Against The Machine">
+              <label for="seed-artist">Seed Artist <small class="text-muted">(finds similar artists)</small></label>
+              <input style="font-size:15px;" type="text" id="seed-artist" class="form-control form-control-lg" name="seed-artist" placeholder="e.g. Radiohead, Kendrick Lamar, Daft Punk...">
             </div>
 
             <br>


### PR DESCRIPTION
The Spotify /recommendations endpoint was deprecated in Nov 2024 for new apps.
This change implements an alternative approach using Last.fm for similar artists
discovery combined with Spotify search for tracks.

Changes:
- Fix token refresh bug (was using wrong URL variable)
- Add Last.fm API integration for similar artists
- Replace audio feature sliders (no longer available) with Variety and Discovery
- Expand genre selection options
- Update frontend to reflect new recommendation approach