### PR TITLE
Add navigation menu and playlist tile grid

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -13,40 +13,57 @@
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
 
   <style>
-    .playlist-item {
-      padding: 14px 12px;
-      border: 2px solid #444;
-      border-radius: 10px;
-      margin-bottom: 12px;
+    .playlist-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+      gap: 14px;
+      padding: 4px;
+    }
+    .playlist-tile {
+      position: relative;
       cursor: pointer;
+      border-radius: 10px;
+      overflow: hidden;
+      border: 2px solid transparent;
       transition: all 0.2s;
-      min-height: 70px;
       -webkit-tap-highlight-color: rgba(29, 185, 84, 0.3);
     }
-    .playlist-item:hover,
-    .playlist-item:active {
-      background-color: #2c3e50;
+    .playlist-tile::before {
+      content: '';
+      display: block;
+      padding-top: 100%;
     }
-    .playlist-item.selected {
-      border-color: #1db954;
-      background-color: #1a472a;
-    }
-    .playlist-img {
-      width: 56px;
-      height: 56px;
+    .playlist-tile-img {
+      position: absolute;
+      top: 0; left: 0;
+      width: 100%; height: 100%;
       object-fit: cover;
-      border-radius: 6px;
-      flex-shrink: 0;
     }
-    .playlist-info {
-      min-width: 0;
-      overflow: hidden;
+    .playlist-tile-label {
+      position: absolute;
+      bottom: 0; left: 0; right: 0;
+      padding: 28px 8px 8px;
+      background: linear-gradient(transparent, rgba(0,0,0,0.85));
+      font-size: 13px;
+      line-height: 1.3;
     }
-    .playlist-info strong {
+    .playlist-tile-label strong {
       display: block;
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
+    }
+    .playlist-tile-label small {
+      opacity: 0.7;
+    }
+    .playlist-tile:hover,
+    .playlist-tile:active {
+      border-color: #555;
+      transform: scale(1.02);
+    }
+    .playlist-tile.selected {
+      border-color: #1db954;
+      box-shadow: 0 0 0 2px #1db954;
     }
     .score-bar {
       height: 24px;
@@ -133,6 +150,10 @@
 
     /* Mobile specific */
     @media (max-width: 768px) {
+      .playlist-grid {
+        grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
+        gap: 10px;
+      }
       .step-card {
         padding: 16px;
         border-radius: 10px;
@@ -165,13 +186,34 @@
         text-align: center;
       }
     }
+    @media (max-width: 400px) {
+      .playlist-grid {
+        grid-template-columns: repeat(auto-fill, minmax(90px, 1fr));
+        gap: 8px;
+      }
+      .playlist-tile-label {
+        font-size: 11px;
+        padding: 20px 6px 6px;
+      }
+    }
   </style>
 </head>
 <body>
-  <nav class="navbar navbar-dark bg-dark">
-    <a style="color: white;" class="navbar-brand" href="{{ url_for('music_profile') }}">
-      <small>My Profile</small>
-    </a>
+  <nav class="navbar navbar-expand-sm navbar-dark bg-dark">
+    <a class="navbar-brand" href="{{ url_for('landing') }}">marcify</a>
+    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#mainNav">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="mainNav">
+      <ul class="navbar-nav ml-auto">
+        <li class="nav-item active">
+          <a class="nav-link" href="{{ url_for('index') }}">Generator</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href="{{ url_for('music_profile') }}">My Profile</a>
+        </li>
+      </ul>
+    </div>
   </nav>
 
   <div id="loading" style="display:none; text-align:center; padding: 50px;">
@@ -328,17 +370,18 @@
         $('#playlists-loading').hide();
 
         if (response.playlists && response.playlists.length > 0) {
-          var html = '';
+          var html = '<div class="playlist-grid">';
           response.playlists.forEach(function(pl) {
-            var img = pl.image || 'https://via.placeholder.com/56?text=♪';
+            var img = pl.image || 'https://via.placeholder.com/300/1a1a2e/555?text=♪';
             var safeName = $('<div>').text(pl.name).html();
-            html += '<div class="playlist-item d-flex align-items-center" data-id="' + pl.id + '" data-name="' + safeName + '">';
-            html += '<img src="' + img + '" class="playlist-img mr-3" alt="">';
-            html += '<div class="playlist-info">';
+            html += '<div class="playlist-tile" data-id="' + pl.id + '" data-name="' + safeName + '">';
+            html += '<img src="' + img + '" class="playlist-tile-img" alt="">';
+            html += '<div class="playlist-tile-label">';
             html += '<strong>' + safeName + '</strong>';
-            html += '<small class="text-muted">' + pl.tracks_total + ' tracks</small>';
+            html += '<small>' + pl.tracks_total + ' tracks</small>';
             html += '</div></div>';
           });
+          html += '</div>';
           $('#playlists-container').html(html);
         } else {
           $('#playlists-container').html('<p class="text-muted text-center py-4">No playlists found</p>');
@@ -354,8 +397,8 @@
     }
 
     // Select playlist
-    $(document).on('click', '.playlist-item', function() {
-      $('.playlist-item').removeClass('selected');
+    $(document).on('click', '.playlist-tile', function() {
+      $('.playlist-tile').removeClass('selected');
       $(this).addClass('selected');
       selectedPlaylistId = $(this).data('id');
       selectedPlaylistName = $(this).data('name');

--- a/app/templates/landing.html
+++ b/app/templates/landing.html
@@ -56,6 +56,23 @@
   </style>
 </head>
 <body>
+  <nav class="navbar navbar-expand-sm navbar-dark bg-dark">
+    <a class="navbar-brand" href="{{ url_for('landing') }}">marcify</a>
+    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#mainNav">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="mainNav">
+      <ul class="navbar-nav ml-auto">
+        <li class="nav-item">
+          <a class="nav-link" href="{{ url_for('index') }}">Generator</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href="{{ url_for('music_profile') }}">My Profile</a>
+        </li>
+      </ul>
+    </div>
+  </nav>
+
   <div class="jumbotron text-center">
     <h1>Magic Music Generator</h1>
     <span class="badge badge-warning">by marcify</span>

--- a/app/templates/profile.html
+++ b/app/templates/profile.html
@@ -108,9 +108,21 @@
   </style>
 </head>
 <body>
-  <nav class="navbar navbar-dark bg-dark">
-    <a style="color: white;" class="navbar-brand" href="{{ url_for('index') }}">Generator</a>
-    <span class="navbar-text text-white">Your Music Profile</span>
+  <nav class="navbar navbar-expand-sm navbar-dark bg-dark">
+    <a class="navbar-brand" href="{{ url_for('landing') }}">marcify</a>
+    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#mainNav">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="mainNav">
+      <ul class="navbar-nav ml-auto">
+        <li class="nav-item">
+          <a class="nav-link" href="{{ url_for('index') }}">Generator</a>
+        </li>
+        <li class="nav-item active">
+          <a class="nav-link" href="{{ url_for('music_profile') }}">My Profile</a>
+        </li>
+      </ul>
+    </div>
   </nav>
 
   <div class="jumbotron text-center">


### PR DESCRIPTION
- Add consistent navbar with hamburger menu across all pages (landing, generator, profile)
- Replace playlist list items with square tile grid using CSS Grid
- Tiles show playlist cover image with name/track count overlay
- Grid adapts to screen size (4 cols desktop, 3 cols tablet, 3 cols phone)
- Active page highlighted in navbar